### PR TITLE
service: Fix hiveserver2 hive.server2.thrift.bind.host

### DIFF
--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftBinaryCLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftBinaryCLIService.java
@@ -158,8 +158,9 @@ public class ThriftBinaryCLIService extends ThriftCLIService {
           currentServerContext.set(serverContext);
         }
       });
-      String msg = "Starting " + ThriftBinaryCLIService.class.getSimpleName() + " on port "
-          + portNum + " with " + minWorkerThreads + "..." + maxWorkerThreads + " worker threads";
+      String msg = "Starting " + ThriftBinaryCLIService.class.getSimpleName()
+          + " on " + hiveHost + ":" + portNum
+          + " with " + minWorkerThreads + "..." + maxWorkerThreads + " worker threads";
       LOG.info(msg);
       server.serve();
     } catch (Throwable t) {

--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftCLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftCLIService.java
@@ -165,7 +165,7 @@ public abstract class ThriftCLIService extends AbstractService implements TCLISe
   public synchronized void init(HiveConf hiveConf) {
     this.hiveConf = hiveConf;
 
-    String hiveHost = System.getenv("HIVE_SERVER2_THRIFT_BIND_HOST");
+    hiveHost = System.getenv("HIVE_SERVER2_THRIFT_BIND_HOST");
     if (hiveHost == null) {
       hiveHost = hiveConf.getVar(ConfVars.HIVE_SERVER2_THRIFT_BIND_HOST);
     }


### PR DESCRIPTION
Shadowing the variable prevented it from being set on the class variable
which is used by all the code in ThriftBinaryCLIService.