### PR TITLE
Dockerfile: Add the summary label and update the description of the images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,7 @@ VOLUME /var/lib/hive
 USER 1002
 
 LABEL io.k8s.display-name="OpenShift Hive" \
-      io.k8s.description="This is an image used by operator-metering to to install and run Apache Hive." \
+      io.k8s.description="This is an image used by the Metering Operator to install and run Apache Hive." \
+      summary="This is an image used by the Metering Operator to install and run Apache Hive." \
       io.openshift.tags="openshift" \
       maintainer="metering-team@redhat.com"

--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -104,6 +104,7 @@ VOLUME /var/lib/hive
 USER 1002
 
 LABEL io.k8s.display-name="OpenShift Hive" \
-      io.k8s.description="This is an image used by operator-metering to to install and run Apache Hive." \
+      io.k8s.description="This is an image used by the Metering Operator to install and run Apache Hive." \
+      summary="This is an image used by the Metering Operator to install and run Apache Hive." \
       io.openshift.tags="openshift" \
       maintainer="metering-team@redhat.com"

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -76,6 +76,7 @@ VOLUME /var/lib/hive
 USER 1002
 
 LABEL io.k8s.display-name="OpenShift Hive" \
-      io.k8s.description="This is an image used by operator-metering to to install and run Apache Hive." \
+      io.k8s.description="This is an image used by the Metering Operator to install and run Apache Hive." \
+      summary="This is an image used by the Metering Operator to install and run Apache Hive." \
       io.openshift.tags="openshift" \
       maintainer="metering-team@redhat.com"

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -60,4 +60,4 @@ USER 1002
 LABEL io.k8s.display-name="OpenShift Hive" \
       io.k8s.description="This is an image used by operator-metering to to install and run Apache Hive." \
       io.openshift.tags="openshift" \
-      maintainer="Chance Zibolski <czibolsk@redhat.com>"
+      maintainer="metering-team@redhat.com"

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -58,6 +58,7 @@ VOLUME /var/lib/hive
 USER 1002
 
 LABEL io.k8s.display-name="OpenShift Hive" \
-      io.k8s.description="This is an image used by operator-metering to to install and run Apache Hive." \
+      io.k8s.description="This is an image used by the Metering Operator to install and run Apache Hive." \
+      summary="This is an image used by the Metering Operator to install and run Apache Hive." \
       io.openshift.tags="openshift" \
       maintainer="metering-team@redhat.com"


### PR DESCRIPTION
Updates the maintainer label in the Dockerfile.rhel8 image to be the mailing list.

Updates the io.k8s.description to remove reference to operator-metering.

Adds the summary field that mirrors the io.k8s.description field.