### PR TITLE
Updating hive builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6 AS build
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift AS build
 
 RUN yum -y install --setopt=skip_missing_names_on_install=False curl
 
@@ -9,7 +9,7 @@ WORKDIR /build
 COPY opt_maven_install.sh /tmp/
 RUN chmod u+x /tmp/opt_maven_install.sh && /tmp/opt_maven_install.sh $OPENSHIFT_CI
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:metering-hadoop
+FROM registry.svc.ci.openshift.org/ocp/4.7:metering-hadoop
 
 ENV HIVE_VERSION=2.3.3
 ENV HIVE_HOME=/opt/hive


### PR DESCRIPTION
Updating hive builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/hive.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/kube-reporting/hadoop/pull/63 . Allow it to merge and then run `/test all` on this PR.