### PR TITLE
Bug 1915563: Ensure the mysql-connector-java jar is present

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -24,11 +24,11 @@ RUN yum -y update && \
     yum install --setopt=skip_missing_names_on_install=False -y \
         postgresql-jdbc \
         openssl \
-        mariadb-java-client \
     && yum clean all \
     && rm -rf /var/cache/yum
 
 COPY --from=build /build/packaging/target/apache-hive-$HIVE_VERSION-bin/apache-hive-$HIVE_VERSION-bin $HIVE_HOME
+COPY --from=build /build/mysql-connector-java.jar /usr/lib/java/mysql-java-connector.jar
 WORKDIR $HIVE_HOME
 
 ENV HADOOP_CLASSPATH $HIVE_HOME/hcatalog/share/hcatalog/*:${HADOOP_CLASSPATH}
@@ -36,7 +36,7 @@ ENV HADOOP_CLASSPATH $HIVE_HOME/hcatalog/share/hcatalog/*:${HADOOP_CLASSPATH}
 # Configure Hadoop AWS Jars to be available to hive
 RUN ln -s ${HADOOP_HOME}/share/hadoop/tools/lib/*aws* $HIVE_HOME/lib
 # Configure MySQL connector jar to be available to hive
-RUN ln -s /usr/lib/java/mariadb-java-client.jar "$HIVE_HOME/lib/mysql-connector-java.jar"
+RUN ln -s /usr/lib/java/mysql-java-connector.jar "$HIVE_HOME/lib/mysql-connector-java.jar"
 # Configure Postgesql connector jar to be available to hive
 RUN ln -s /usr/share/java/postgresql-jdbc.jar "$HIVE_HOME/lib/postgresql-jdbc.jar"
 


### PR DESCRIPTION
Update the `opt_maven_install.sh` helper script, which is used to help combine the ART and CI Dockerfiles, to get the mysql-connector-java JDBC driver JAR in the Hive image. We use to get this package for free before the introduction of RHEL8 base images during the 4.6 release, and that package was swapped out for the mariadb equalivent. This is causing upgrades to fail from <4.6 metering versions to 4.6+ as that package is no longer present.

In the case of ART, pull from PNC build, else pull from maven and copy that JAR into the destination container.

This image was tested by deploying metering with the Hive image that CI outputted (and mirrored to quay to avoid setting up pull secrets). This results in the following MeteringConfig custom resource:

```yaml
apiVersion: metering.openshift.io/v1
kind: MeteringConfig
metadata:
  name: "operator-metering"
  annotations:
    "ansible.operator-sdk/verbosity": "1"
spec:
  unsupportedFeatures:
    enableHDFS: true

  storage:
    type: "hive"
    hive:
      type: "hdfs"
      hdfs:
        namenode: "hdfs-namenode-0.hdfs-namenode:9820"

  hive:
    spec:
      image:
        repository: quay.io/tflannag/hive
        tag: mysql
      config:
        db:
          driver: com.mysql.jdbc.Driver
          username: testuser
          password: testpass
          url: jdbc:mysql://mysql.tflannag.svc.cluster.local:3306/metastore
```

The MySQL instance is 5.7, which was created using the `registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe` image. I imported that image as an ImageStream and created that instance using `oc new-app ...`.
