### PR TITLE
Dockerfile: Minor changes to force a Hive CI rebuild

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -19,13 +19,10 @@ RUN mkdir -p /opt
 WORKDIR /opt
 
 USER root
-
 RUN yum -y update && \
-    yum install --setopt=skip_missing_names_on_install=False -y \
-        postgresql-jdbc \
-        openssl \
-    && yum clean all \
-    && rm -rf /var/cache/yum
+    yum install --setopt=skip_missing_names_on_install=False -y postgresql-jdbc openssl && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 COPY --from=build /build/packaging/target/apache-hive-$HIVE_VERSION-bin/apache-hive-$HIVE_VERSION-bin $HIVE_HOME
 COPY --from=build /build/mysql-connector-java.jar /usr/lib/java/mysql-java-connector.jar


### PR DESCRIPTION
Minor cosmetic changes to the rhel8 Dockerfile to force a rebuild of the
CI Hive image. This image appears to be using the non-reverted Hadoop
changes and causing e2e failures in the metering-operator repository.

It's likely those failures are due to guava version mismatches between
what we specify in the Hive root pom.xml and the various Hadoop pom.xml's:

```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/hive/lib/log4j-slf4j-impl-2.6.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/hadoop/share/hadoop/common/lib/slf4j-log4j12-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
21/02/14 20:42:18 [main]: INFO conf.HiveConf: Found configuration file file:/opt/hive/conf/hive-site.xml
Exception in thread "main" java.lang.NoSuchMethodError: com.google.common.base.Preconditions.checkArgument(ZLjava/lang/String;Ljava/lang/Object;)V
	at org.apache.hadoop.conf.Configuration.set(Configuration.java:1357)
	at org.apache.hadoop.conf.Configuration.set(Configuration.java:1338)
	at org.apache.hadoop.mapred.JobConf.setJar(JobConf.java:518)
	at org.apache.hadoop.mapred.JobConf.setJarByClass(JobConf.java:536)
	at org.apache.hadoop.mapred.JobConf.<init>(JobConf.java:430)
	at org.apache.hadoop.hive.conf.HiveConf.initialize(HiveConf.java:4047)
	at org.apache.hadoop.hive.conf.HiveConf.<init>(HiveConf.java:4010)
	at org.apache.hive.beeline.HiveSchemaTool.<init>(HiveSchemaTool.java:82)
	at org.apache.hive.beeline.HiveSchemaTool.main(HiveSchemaTool.java:1117)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.util.RunJar.run(RunJar.java:318)
	at org.apache.hadoop.util.RunJar.main(RunJar.java:232)
```