### PR TITLE
[release-4.6] Use fetch-artifacts-koji to download .jar files in OCP build

### DIFF
--- a/fetch-artifacts-koji.yaml
+++ b/fetch-artifacts-koji.yaml
@@ -1,0 +1,9 @@
+- nvr: org.apache.hive-hive-2.3.3.redhat_00002-1
+  archives:
+  - filename: hive-packaging-2.3.3.redhat-00002-bin.tar.gz
+    group_id: org.apache.hive
+- nvr: mysql-mysql-connector-java-8.0.21.redhat_00001-1
+  archives:
+  - filename: mysql-connector-java-8.0.21.redhat-00001.jar
+    group_id: mysql
+

--- a/opt_maven_install.sh
+++ b/opt_maven_install.sh
@@ -22,10 +22,11 @@ if [[ "$1" == "true" ]]; then
   	mvn -B -e -T 1C -DskipTests=true -DfailIfNoTests=false -Dtest=false clean package -Pdist
 else
     # Otherwise this is a production brew build by ART
+        MAVEN_REPO_URL=${MAVEN_REPO_URL:-file:///build/artifacts}
 	export RH_HIVE_PATCH_VERSION=00002
 	export HIVE_VERSION=2.3.3
 
-	export HIVE_RELEASE_URL=http://download.eng.bos.redhat.com/brewroot/packages/org.apache.hive-hive/${HIVE_VERSION}.redhat_${RH_HIVE_PATCH_VERSION}/1/maven/org/apache/hive/hive-packaging/${HIVE_VERSION}.redhat-${RH_HIVE_PATCH_VERSION}/hive-packaging-${HIVE_VERSION}.redhat-${RH_HIVE_PATCH_VERSION}-bin.tar.gz
+	export HIVE_RELEASE_URL=$MAVEN_REPO_URL/org/apache/hive/hive-packaging/${HIVE_VERSION}.redhat-${RH_HIVE_PATCH_VERSION}/hive-packaging-${HIVE_VERSION}.redhat-${RH_HIVE_PATCH_VERSION}-bin.tar.gz
 	export HIVE_OUT=/build/packaging/target/apache-hive-$HIVE_VERSION-bin/apache-hive-$HIVE_VERSION-bin
 
 	curl -fSLs \
@@ -43,6 +44,6 @@ else
 	# the correct path in the destination container in the Dockerfile workflow.
 	export RH_MYSQL_CONNECTOR_PATCH_VERSION=00001
 	curl -fSLs \
-		http://download.eng.bos.redhat.com/brewroot/packages/mysql-mysql-connector-java/${MYSQL_VERSION}.redhat_${RH_MYSQL_CONNECTOR_PATCH_VERSION}/1/maven/mysql/mysql-connector-java/${MYSQL_VERSION}.redhat-${RH_MYSQL_CONNECTOR_PATCH_VERSION}/mysql-connector-java-${MYSQL_VERSION}.redhat-${RH_MYSQL_CONNECTOR_PATCH_VERSION}.jar \
+		$MAVEN_REPO_URL/mysql/mysql-connector-java/${MYSQL_VERSION}.redhat-${RH_MYSQL_CONNECTOR_PATCH_VERSION}/mysql-connector-java-${MYSQL_VERSION}.redhat-${RH_MYSQL_CONNECTOR_PATCH_VERSION}.jar \
 		-o /build/mysql-connector-java.jar
 fi


### PR DESCRIPTION
ART is asked to move all container-first images to the new source container workflow by Jun 3, 2022. This includes metering images like hadoop, hive, and presto. Images failing to migrate to the new source container workflow by this date will not have their sources shipped to customers and lose the compliance with legal requirements. ART has completed most of the work for moving to the new workflow, but there are still few things left.

The new workflow will no longer allow to download .jar files directly from Dockerfile. We have to use configuration files (like fetch-artifacts-koji.yaml, fetch-artifacts-pnc.yaml, etc) to instruct OSBS to download the specified artifacts. For more information, see https://osbs.readthedocs.io/en/osbs_ocp3/users.html#using-artifacts-from-koji-or-project-newcastle-aka-pnc.